### PR TITLE
FIX: the image pull policy for ctlog, logserver, and signer

### DIFF
--- a/config/ctlog/ctlog/300-ctlog.yaml
+++ b/config/ctlog/ctlog/300-ctlog.yaml
@@ -26,7 +26,6 @@ spec:
             "--log_config=/ctfe-config/ct_server.cfg",
             "--alsologtostderr"
           ]
-          imagePullPolicy: Always
           volumeMounts:
           - name: keys
             mountPath: "/ctfe-keys"

--- a/config/trillian/trillian-log-server/300-log-server.yaml
+++ b/config/trillian/trillian-log-server/300-log-server.yaml
@@ -52,7 +52,6 @@ spec:
               secretKeyRef:
                 name: trillian-client
                 key: host
-        imagePullPolicy: Always
         ports:
         - name: h2c
           containerPort: 8090

--- a/config/trillian/trillian-log-signer/300-log-signer.yaml
+++ b/config/trillian/trillian-log-signer/300-log-signer.yaml
@@ -67,7 +67,6 @@ spec:
                 name: trillian-client
                 key: host
         image: ko://github.com/google/trillian/cmd/trillian_log_signer
-        imagePullPolicy: Always
         ports:
         - name: h2c
           containerPort: 8090

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -7,10 +7,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ -z "${GITHUB_WORKSPACE}" ]]; then
-  echo "This script is expected to run in the context of GitHub Actions."
-  exit 1
-fi
+#if [[ -z "${GITHUB_WORKSPACE}" ]]; then
+#  echo "This script is expected to run in the context of GitHub Actions."
+#  exit 1
+#fi
 
 # Defaults
 K8S_VERSION="v1.21.x"


### PR DESCRIPTION
worked with @vaikas and saw that image was being pulled from external registry with the current pull policy.  removed from those yaml files.